### PR TITLE
Update theme for PHP 8.3 compatibility

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -66,11 +66,11 @@ function pagination_pornstar()
 	$number = get_option('pornstar_page_number', false);
 	if (!$number)
 		$number = 10;
-	$episodes = get_terms('toro_pornstar', array(
-		'hide_empty'    => 0,
-		'number'        => 30000,
-	));
-	$categories = count($episodes);
+        $episodes = get_terms('toro_pornstar', array(
+                'hide_empty'    => 0,
+                'number'        => 30000,
+        ));
+        $categories = is_countable($episodes) ? count($episodes) : 0;
 	global $wp_query, $wp_rewrite;
 	$wp_query->query_vars['paged'] > 1 ? $current = $wp_query->query_vars['paged'] : $current = 1;
 	$pagination = array(

--- a/includes/class-eroz-master.php
+++ b/includes/class-eroz-master.php
@@ -4,6 +4,15 @@ class EROZ_Master
     protected $cargador;
     protected $theme_name;
     protected $version;
+    protected $bct_admin;
+    protected $bct_public;
+    protected $eroz_public_ajax;
+    protected $eroz_admin_ajax;
+    protected $toro_create_taxonomy;
+    protected $toro_permalink;
+    protected $eroz_support;
+    protected $sidebar;
+    protected $cpt;
     /*Construct*/
     public function __construct()
     {

--- a/includes/class-eroz-public-ajax.php
+++ b/includes/class-eroz-public-ajax.php
@@ -49,7 +49,7 @@ class EROZ_public_ajax {
                     $video_0 = $embed_ace;
                 } 
 
-                if (strpos($video_0, '[fvplayer') !== false) { $video_0 = do_shortcode($video_0); }
+                if ($video_0 && strpos($video_0, '[fvplayer') !== false) { $video_0 = do_shortcode($video_0); }
                 if($video_0){$videos[] = $video_0;}
             }
             $video_1     = get_post_meta( $id, $input_video, true );

--- a/single.php
+++ b/single.php
@@ -49,7 +49,7 @@ if(have_posts()) : while(have_posts()) : the_post();?>
 				$video_0 = $embed_ace;
 			} 
 
-            if (strpos($video_0, '[fvplayer') !== false) { $video_0 = do_shortcode($video_0); }
+            if ($video_0 && strpos($video_0, '[fvplayer') !== false) { $video_0 = do_shortcode($video_0); }
             if($video_0){$videos[] = $video_0;}
         }
 


### PR DESCRIPTION
## Summary
- declare properties in `EROZ_Master`
- guard count() with is_countable
- avoid strpos() on non-string values in AJAX handler and template

## Testing
- `php -l includes/class-eroz-master.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68463880c6188330ae1347f51f9a026a