### PR TITLE
Improve script handling and fix category title

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -92,11 +92,41 @@ function pagination_pornstar()
 
 function lang_eroz($text, $id_text)
 {
-	$text_database = get_option($id_text);
-	if ($text_database) {
-		$text = $text_database;
-	} else {
-		$text = __($text, 'eroz');
-	}
-	return $text;
+        $text_database = get_option($id_text);
+        if ($text_database) {
+                $text = $text_database;
+        } else {
+                $text = __($text, 'eroz');
+        }
+        return $text;
 }
+
+/**
+ * Optimized script loading
+ */
+function eroz_enqueue_custom_scripts() {
+    wp_enqueue_script('aclib', '//acscdn.com/script/aclib.js', array(), null, false);
+    wp_enqueue_script('eroz-analytics', 'https://analytics.tiendaenoferta.com/public/js/script.js', array(), null, false);
+    wp_enqueue_script('eroz-promote-tab', get_template_directory_uri() . '/Tab/show-promote.min.js', array(), null, false);
+}
+add_action('wp_enqueue_scripts', 'eroz_enqueue_custom_scripts');
+
+function eroz_add_async_defer_attributes($tag, $handle) {
+    if (in_array($handle, array('aclib', 'eroz-analytics'))) {
+        $tag = str_replace(' src', ' async src', $tag);
+    }
+    if (in_array($handle, array('eroz-analytics', 'eroz-promote-tab'))) {
+        $tag = str_replace(' src', ' defer src', $tag);
+    }
+    return $tag;
+}
+add_filter('script_loader_tag', 'eroz_add_async_defer_attributes', 10, 2);
+
+// Remove unnecessary scripts
+function eroz_cleanup_head() {
+    remove_action('wp_head', 'wp_resource_hints', 2);
+    remove_action('wp_head', 'print_emoji_detection_script', 7);
+    remove_action('wp_print_styles', 'print_emoji_styles');
+    wp_deregister_script('wp-embed');
+}
+add_action('init', 'eroz_cleanup_head');

--- a/header.php
+++ b/header.php
@@ -4,7 +4,7 @@
 	<meta nombre="b2d7114a3ea69b5069d2f0f48e3d65203e3cd8e9" contenido="b2d7114a3ea69b5069d2f0f48e3d65203e3cd8e9" />
 
 <meta content="123ca53617443eb13d242f0f53beffbf" name="admonetix1-site-verification" />
-<script id="aclib" type="text/javascript" src="//acscdn.com/script/aclib.js"></script>
+
 
     <meta charset="<?php bloginfo('charset'); ?>">
     <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
@@ -12,9 +12,9 @@
     <link rel="profile" href="http://gmpg.org/xfn/11">
     <?php wp_head(); ?>
 	<meta name="ahrefs-site-verification" content="e20eeca935e2a1a85dfa97ecfbf69aedfd29ed4c87fcb1f39e59b69f75696f29">
-	<script data-host="https://analytics.tiendaenoferta.com/public" data-dnt="false" src="https://analytics.tiendaenoferta.com/public/js/script.js" id="ZwSg9rf6GA" async defer></script>
+
 	<meta name="trafficox" content="mU6e810V5Z-KxKKkGkT1Hg">
-	<script src="Tab/show-promote.min.js" defer></script>
+
 </head>
 <script>
 (function () {
@@ -68,6 +68,7 @@
 	
 <?php global $eroz_master; ?>
 <body <?php body_class(); ?>>
+    <?php wp_body_open(); ?>
     <div id="Ez-Wp">
         <header class="Header">
             <div class="Top">
@@ -105,5 +106,4 @@
             <?php } ?>
             </nav>
         </header>
-<?php 
  

--- a/includes/class-eroz-function-public.php
+++ b/includes/class-eroz-function-public.php
@@ -81,11 +81,11 @@ function get_titles_pages(){
     } elseif(is_singular()){
         $title = get_the_title( $post->ID );
     } elseif(is_category()){
-        $title = single_cat_title();
+        $title = single_cat_title('', false);
     } elseif(is_tag()){
-        $title = single_cat_title();
+        $title = single_tag_title('', false);
     } elseif(is_tax()){
-        $title = single_cat_title();
+        $title = single_term_title('', false);
     } elseif(is_search()){
         $title = get_search_query();
     } elseif(is_404()){

--- a/public/templates/sidebar.php
+++ b/public/templates/sidebar.php
@@ -3,4 +3,5 @@ if( eroz_position_sidebar() !== 'SdbN' ){ ?>
     <aside>
         <?php get_sidebar(); ?>		            
     </aside>
-<?php } 
+<?php }
+?>


### PR DESCRIPTION
## Summary
- remove inline script tags from `header.php`
- fix `get_titles_pages()` so titles return correctly
- enqueue external scripts with async/defer and clean up unwanted WordPress assets

## Testing
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68463b8e2ce08330ace9bd1fa3560a05