### PR TITLE
Improve PHP 8.3 compatibility

### DIFF
--- a/admin/partials/eroz-report-post_page_admin.php
+++ b/admin/partials/eroz-report-post_page_admin.php
@@ -33,13 +33,13 @@
                                 <tr>
                                     <td class="frst"><?php echo $con; ?></td>
                                     <td><a class="row-title" target="_blank" href="<?php the_permalink(); ?>"><?php the_title(); ?></a></td>
-                                    <td><?php $values = get_post_custom_values("_repor"); echo $values[0]; ?></td>
+                                    <td><?php $values = get_post_custom_values('_repor'); echo !empty($values) ? $values[0] : ''; ?></td>
                                     <td><a data-id="<?php the_ID(); ?>"class="clean-report"><span class="dashicons dashicons-trash"></span> <?php _e('Delete', 'eroz'); ?></a></td>
                                 </tr>
                             <?php $con++;
                             endwhile;
                         endif;
-                        wp_reset_query();
+                        wp_reset_postdata();
                     } ?>
                 </tbody>
             </table>

--- a/functions.php
+++ b/functions.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 global $wpdb;
 
 $_details = wp_get_theme('eroz');

--- a/includes/class-eroz-cpt.php
+++ b/includes/class-eroz-cpt.php
@@ -1,4 +1,5 @@
-<?php 
+<?php
+declare(strict_types=1);
 class EROZ_Create_CustomPostType {
     public function blog() {
         self::create_CustomPostType('blog', 'Blog', 'blog_cpt');

--- a/includes/class-eroz-function-public.php
+++ b/includes/class-eroz-function-public.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 /**
  * Position Sidebar
  *   1. Left = SdbL
@@ -64,8 +65,13 @@ function get_breadcrumb(){
     if(is_page()) { ?>
         <p class="Breadcrumb fa-home"><a href="<?php echo esc_url( home_url() ); ?>"><?php _e('Home', 'eroz'); ?></a> <span class="fa-chevron-right"></span> <strong><?php echo get_the_title(); ?></strong></p>
     <?php } elseif(is_single()) { 
-        $category = get_the_category(); ?>
-        <p class="Breadcrumb fa-home"><a href="<?php echo esc_url( home_url() ); ?>"><?php _e('Home', 'eroz'); ?></a> <span class="fa-chevron-right"></span> <a href="<?php echo get_category_link( $category[0]->term_id ); ?>"><?php echo $category[0]->cat_name; ?></a> <span class="fa-chevron-right"></span> <strong><?php echo get_the_title(); ?></strong></p>
+        $category = get_the_category();
+        if ( ! empty( $category ) ) {
+            $first_cat = $category[0];
+            ?>
+            <p class="Breadcrumb fa-home"><a href="<?php echo esc_url( home_url() ); ?>"><?php _e('Home', 'eroz'); ?></a> <span class="fa-chevron-right"></span> <a href="<?php echo get_category_link( $first_cat->term_id ); ?>"><?php echo $first_cat->cat_name; ?></a> <span class="fa-chevron-right"></span> <strong><?php echo get_the_title(); ?></strong></p>
+            <?php
+        }
     <?php } elseif(is_category() or is_tag()) { ?>
         <p class="Breadcrumb fa-home"><a href="<?php echo esc_url( home_url() ); ?>"><?php _e('Home', 'eroz'); ?></a> <span class="fa-chevron-right"></span> <strong><?php single_cat_title(); ?></strong></p>
     <?php } else { ?>

--- a/includes/function-eroz-do-action.php
+++ b/includes/function-eroz-do-action.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /**
  * home.php
@@ -37,7 +38,11 @@ function do_action_home_categories_recommended(){
                 <section class="Eroz-Thumbs List">
                     <?php 
                     if($order_cat == 'random') {
-                        $categories = get_terms('category', 'orderby=name&order= ASC&hide_empty=0');
+                        $categories = get_terms('category', array(
+                            'orderby'    => 'name',
+                            'order'      => 'ASC',
+                            'hide_empty' => 0
+                        ));
                         shuffle($categories);
                         $categories = array_slice($categories, 0, $number_cat);
                     } else {
@@ -89,12 +94,12 @@ function do_action_footer_description(){
                 </section>
             <?php } 
         } elseif(is_single()) { 
-            global $post; 
-            $desc = get_post_meta( $post->ID, 'eroz_post_desc' ); 
-            if($desc){ ?>
+            global $post;
+            $desc = get_post_meta( $post->ID, 'eroz_post_desc', true );
+            if ( $desc ) { ?>
                 <section class="Top">
                     <div class="Description Container">
-                        <?php echo $desc[0]; ?>
+                        <?php echo $desc; ?>
                     </div>
                 </section>
             <?php }
@@ -254,7 +259,7 @@ function do_action_single_related() {
                 while ( $the_related->have_posts() ) : $the_related->the_post(); 
                     get_template_part( 'public/templates/loop', 'principal' );
                 endwhile;
-            wp_reset_query(); ?>
+            wp_reset_postdata(); ?>
         </section>
     <?php endif;  
 }

--- a/includes/function-eroz-widgets.php
+++ b/includes/function-eroz-widgets.php
@@ -1,4 +1,5 @@
-<?php 
+<?php
+declare(strict_types=1);
 /**
  * WIDGET CATEGORY - TAG : LIST
  * v.1.0.1
@@ -69,9 +70,9 @@ class widget_categories extends WP_Widget {
         <?php
     }
     public function update( $new_instance, $old_instance ) {
-        foreach( $new_instance as $key => $value )
-        {
-            $updated_instance[$key] = sanitize_text_field($value);
+        $updated_instance = [];
+        foreach ( $new_instance as $key => $value ) {
+            $updated_instance[ $key ] = sanitize_text_field( $value );
         }
         return $updated_instance;
     }
@@ -127,7 +128,7 @@ class widget_post_election extends WP_Widget {
             if ( $the_query->have_posts() ) :
                 while ( $the_query->have_posts() ) : $the_query->the_post(); 
                     get_template_part( 'public/templates/loop', 'principal' );
-                endwhile; endif; wp_reset_query(); ?>
+                endwhile; endif; wp_reset_postdata(); ?>
         </div>
         <?php if($more != ''){ ?>
             <a href="<?php echo $more; ?>" class="Button A Sm fa-arrow-right"><?php _e('View All', 'eroz'); ?></a>
@@ -161,9 +162,9 @@ class widget_post_election extends WP_Widget {
         <?php
     }
     public function update( $new_instance, $old_instance ) {
-        foreach( $new_instance as $key => $value )
-        {
-            $updated_instance[$key] = sanitize_text_field($value);
+        $updated_instance = [];
+        foreach ( $new_instance as $key => $value ) {
+            $updated_instance[ $key ] = sanitize_text_field( $value );
         }
         return $updated_instance;
     }

--- a/includes/widgets/home/wdgt_categories.php
+++ b/includes/widgets/home/wdgt_categories.php
@@ -1,4 +1,5 @@
-<?php 
+<?php
+declare(strict_types=1);
 add_action( 'widgets_init', function(){
     register_widget( 'wdgt_categories' );
 });
@@ -28,7 +29,11 @@ class wdgt_categories extends WP_Widget {
         <section class="Eroz-Thumbs List">
             <?php 
             if($order_cat == 'random') {
-                $categories = get_terms('category', 'orderby=name&order= ASC&hide_empty=0');
+                $categories = get_terms('category', array(
+                    'orderby'    => 'name',
+                    'order'      => 'ASC',
+                    'hide_empty' => 0
+                ));
                 shuffle($categories);
                 $categories = array_slice($categories, 0, $number);
             } else {
@@ -116,9 +121,9 @@ class wdgt_categories extends WP_Widget {
     #Save Data
     public function update( $new_instance, $old_instance ) {
         // processes widget options to be saved
-        foreach( $new_instance as $key => $value )
-        {
-            $updated_instance[$key] = sanitize_text_field($value);
+        $updated_instance = [];
+        foreach ( $new_instance as $key => $value ) {
+            $updated_instance[ $key ] = sanitize_text_field( $value );
         }
         return $updated_instance;
     }

--- a/includes/widgets/home/wdgt_pornstars.php
+++ b/includes/widgets/home/wdgt_pornstars.php
@@ -1,4 +1,5 @@
-<?php 
+<?php
+declare(strict_types=1);
 add_action( 'widgets_init', function(){
     register_widget( 'wdgt_pornstar' );
 });
@@ -78,9 +79,9 @@ class wdgt_pornstar extends WP_Widget {
     #Save Data
     public function update( $new_instance, $old_instance ) {
         // processes widget options to be saved
-        foreach( $new_instance as $key => $value )
-        {
-            $updated_instance[$key] = sanitize_text_field($value);
+        $updated_instance = [];
+        foreach ( $new_instance as $key => $value ) {
+            $updated_instance[ $key ] = sanitize_text_field( $value );
         }
         return $updated_instance;
     }

--- a/pages/page-like.php
+++ b/pages/page-like.php
@@ -36,7 +36,7 @@ get_header(); ?>
                         </div> 
                     <?php else: ?> 
                         <div> <?php _e('No hay articulos', 'eroz'); ?> </div>
-                    <?php endif; wp_reset_query();  ?>
+                    <?php endif; wp_reset_postdata();  ?>
                 </section>
             </main> 
             <?php get_template_part( 'public/templates/sidebar' ); ?>

--- a/pages/page-likeuser.php
+++ b/pages/page-likeuser.php
@@ -47,7 +47,7 @@ if(isset($_COOKIE['vote_er']))
                                 <div>
                                     <?php _e('No hay articulos', 'eroz'); ?>
                                 </div>
-                            <?php endif; wp_reset_query();  ?>
+                            <?php endif; wp_reset_postdata();  ?>
                         <?php } ?>
                     </section>
                 </main>

--- a/pages/page-views.php
+++ b/pages/page-views.php
@@ -36,7 +36,7 @@ get_header(); ?>
                         </div> 
                     <?php else: ?> 
                         <div> <?php _e('No hay articulos', 'eroz'); ?> </div>
-                    <?php endif; wp_reset_query(); ?>
+                    <?php endif; wp_reset_postdata(); ?>
                 </section>
             </main> 
             <?php get_template_part( 'public/templates/sidebar' ); ?>

--- a/single.php
+++ b/single.php
@@ -1,4 +1,4 @@
-<?php get_header(); 
+<?php declare(strict_types=1); get_header();
 if(have_posts()) : while(have_posts()) : the_post();?>
     <div class="Body">
         <?php $ads_video_top   = get_option( 'eroz_ads_single_top');
@@ -138,8 +138,17 @@ if(have_posts()) : while(have_posts()) : the_post();?>
                             $content = preg_replace("/(<iframe[^<]+<\/iframe>)/", '', $content); ?>
                             <?php echo $content; ?>
                         </div>
-                        <p class="entry-meta"><?php if(get_post_meta( $post->ID, 'views' )[0]){ ?><span class="Views fa-eye"><?php echo get_post_meta( $post->ID, 'views' )[0]; ?></span><?php } ?> <?php $input_duration = get_option( 'eroz_meta_duration', true ); if(get_post_meta( $post->ID, $input_duration)[0] and secondtotime(get_post_meta( $post->ID, $input_duration, true ))){ ?><span class="Time fa-clock"><?php 
-                            echo secondtotime(get_post_meta( $post->ID, $input_duration, true )); ?></span><?php } ?></p>
+                        <p class="entry-meta"><?php
+                            $views_count = get_post_meta( $post->ID, 'views', true );
+                            if ( $views_count ) {
+                                ?><span class="Views fa-eye"><?php echo $views_count; ?></span><?php
+                            }
+                            $input_duration = get_option( 'eroz_meta_duration', true );
+                            $duration_meta  = get_post_meta( $post->ID, $input_duration, true );
+                            if ( $duration_meta && secondtotime( $duration_meta ) ) {
+                                ?><span class="Time fa-clock"><?php echo secondtotime( $duration_meta ); ?></span><?php
+                            }
+                        ?></p>
                         <p class="title fa-folder"><?php _e( 'Categories', 'eroz' ); ?> </p>
                         <p class="EzLinks"><?php get_terms_taxonomy('category'); ?></p>
                         <?php $tags_list = get_the_tag_list( '', '', '', $post->id); 


### PR DESCRIPTION
## Summary
- enable strict types
- fix meta access and widget updates
- improve breadcrumb handling
- update category listing queries
- replace deprecated `wp_reset_query()`

## Testing
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68464a61a8d48330a9bea168a2d4d5a2